### PR TITLE
Release Pipeline Fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = False
 message = Bump version: {current_version} → {new_version}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 0.3.0
+  VERSION: 0.3.1
 
 jobs:
   docker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sp-devsup-vault-expiration-monitoring"
-version = "0.3.0"
+version = "0.3.1"
 description = "Prometheus exporter to monitor custom metadata for KV2 secrets for (self-imposed) expiration."
 authors = ["Eugene Davis <eugene.davis@tomtom.com>"]
 readme = "README.md"


### PR DESCRIPTION
An auto-generated release for 0.2.0 can be found at https://github.com/tomtom-internal/sp-devsup-vault-expiration-monitoring/releases

And docker images push here https://hub.docker.com/repository/docker/tomtomcom/vault-expiration-monitor