### PR TITLE
Pr scoped images

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.10
+current_version = 1.0.11
 commit = True
 tag = False
 message = Bump version: {current_version} → {new_version}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -93,7 +93,7 @@ jobs:
         context: .
         tags: ghcr.io/${{ github.repository }}:pr-${{ steps.pr.outputs.id }}
         platforms: linux/amd64,linux/arm64,linux/arm/v7
-      if: ${{ !steps.containers.outputs.BUILD_PR }}
+      if: ${{ !fromJSON(steps.containers.outputs.BUILD_PR) }}
 
   security:
     name: security checks

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,7 +3,6 @@ name: PR Checks
 on:
   pull_request:
     branches: [ main ]
-  workflow_dispatch:
 
 env:
   REQUIRED_COVERAGE: 30
@@ -12,7 +11,6 @@ jobs:
   python:
     name: python checks
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -46,6 +44,25 @@ jobs:
     - uses: hadolint/hadolint-action@v2.0.0
       with:
         dockerfile: Dockerfile
+        
+    - name: Build PR Check
+      id: containers
+      run: |
+       if [[ "${{ secrets.BUILD_PR }}" != "" && \
+             "${{ secrets.PR_CONTAINERS_USER }}" != "" && \
+             "${{ secrets.PR_CONTAINERS }}" != "" ]]
+       then
+         echo "PR Builds configured"
+         echo "::set-output name=BUILD_PR::true"
+       else
+         echo "PR Builds not configured"
+         echo "::set-output name=BUILD_PR::false"
+       fi
+
+    - name: Get PR ID
+      id: pr
+      run: echo "::set-output name=id::$(echo ${{ github.ref_name }} | cut -d"/" -f1)"
+      if: ${{ fromJSON(steps.containers.outputs.BUILD_PR) }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -53,11 +70,30 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Test Cross Platform Build
+    - name: Login to ghcr.io
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.PR_CONTAINERS_USER }}
+        password: ${{ secrets.PR_CONTAINERS }}
+      if: ${{ fromJSON(steps.containers.outputs.BUILD_PR) }}
+
+    - name: PR Cross Platform Build and Push
       uses: docker/build-push-action@v2
       with:
         context: .
+        push: true
+        tags: ghcr.io/${{ github.repository }}:pr-${{ steps.pr.outputs.id }}
         platforms: linux/amd64,linux/arm64,linux/arm/v7
+      if: ${{ fromJSON(steps.containers.outputs.BUILD_PR) }}
+
+    - name: PR Cross Platform Build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: ghcr.io/${{ github.repository }}:pr-${{ steps.pr.outputs.id }}
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+      if: ${{ !steps.containers.outputs.BUILD_PR }}
 
   security:
     name: security checks

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [closed]
 
-env:
-  BUILD_PR: ${{ secrets.BULD_PR }}
 
 jobs:
   purge-image:

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,0 +1,35 @@
+name: 'Clean up Docker images from PR'
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  BUILD_PR: ${{ secrets.BULD_PR }}
+
+jobs:
+  purge-image:
+    name: Delete image from ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build PR Check
+      id: containers
+      run: |
+       if [[ "${{ secrets.BUILD_PR }}" != "" && \
+             "${{ secrets.PR_CONTAINERS_USER }}" != "" && \
+             "${{ secrets.PR_CONTAINERS }}" != "" ]]
+       then
+         echo "PR Builds configured"
+         echo "::set-output name=BUILD_PR::true"
+       else
+         echo "PR Builds not configured"
+         echo "::set-output name=BUILD_PR::false"
+       fi
+       
+    - uses: eugene-davis/action-cleanup-package@v1.1.0
+      with:
+        package-name: ${{ github.event.repository.name }}
+        tag: pr-${{ github.event.pull_request.number }}
+        github-token: ${{ secrets.PR_CONTAINERS }}
+        github-org: ${{ secrets.ORG}} # Should only be set when running in an organization
+      if: ${{ fromJSON(steps.containers.outputs.BUILD_PR) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.0.10
+  VERSION: 1.0.11
 
 jobs:
   release:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,18 @@ To help protect the health of this project, all contributions are required to pa
 
 * [gitleaks](https://github.com/zricethezav/gitleaks) - scans the repository for possible secrets (e.g. passwords, keys), this is only the last line of defense, you should double-check before you commit!
 * [bump2version](https://github.com/c4urself/bump2version) - we ensure that the version has been bumped by bump2version on every pull request
+
+#### Automatic PR Builds
+
+The [Docker Checks](#docker-checks) job can be configured to push a PR build image (tagged pr-#) to your repository.
+It does not work when running from a forked repository.
+This image will be cleaned up after the PR is closed.
+Using this functionality requires the following secrets to be added:
+
+* `BULD_PR` must be set to `true`
+* `PR_CONTAINERS_USER` must be set to the user associated with the `PR_CONTAINERS` token
+* `PR_CONTAINERS` must be set to a Github PAT with `read`, `write` and `delete` packages permissions
+
+A PAT must be used rather than the built-in token, as Github Actions does not currently support setting the `delete` permission for packages on the default token.
+
+If you wish to enable the functionality in an organization, you must also provide the organization name in a secret called `ORG`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vault-assessment-prometheus-exporter"
-version = "1.0.10"
+version = "1.0.11"
 description = "Prometheus exporter to monitor custom metadata for KV2 secrets for (self-imposed) expiration."
 authors = ["Eugene Davis <eugene.davis@tomtom.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request

Adds an optional build  for PRs as per #43, which is  uploaded with the  tag  `pr-<-number>` and is deleted whenever the PR is closed.

Due to limitations in Github actions (the  built-in token cannot currently have delete permissions on packages), this requires adding a PAT token with the appropriate permissions - as such the  jobs checks to see that the appropriate secrets are available, otherwise it does not attempt to upload the container.

Also, since forked PRs cannot access Github Actions secrets, this only runs on internal PRs (allowing a contributor to work either within their own fork, or within the main repo when using these images).

Testing:

* Forked (ignored): https://github.com/tomtom-international/vault-assessment-prometheus-exporter/runs/7270342605?check_suite_focus=true
* On a personal repo (fork): https://github.com/eugene-davis/vault-assessment-prometheus-exporter/runs/7270376903?check_suite_focus=true
* On the org repo: https://github.com/tomtom-international/vault-assessment-prometheus-exporter/runs/7270022107?check_suite_focus=true

## Prior to Submitting

Please confirm the following:

* [x] I agree to the [Developer Certificate of Origin](https://developercertificate.org/)
* [x] I have read the [Contribution Document](CONTRIBUTING.md)
* [x] I updated any user-documentation that is impacted by my change.
* [x] I tested my changes and ensured existing functionality wasn't broken.
* [ ] [optional] I tested my changes on all the supported platforms.
* [ ] [optional] In case of a major change, I communicated with the maintainers via an issue or email.