### PR TITLE
Add support for monitor_flag to filter secrets by metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.8-alpine3.16 as builder
+FROM python:3.10.8-alpine3.16 AS builder
 
 COPY . /build
 

--- a/docs/CONFIGURATION_EXAMPLES.md
+++ b/docs/CONFIGURATION_EXAMPLES.md
@@ -62,6 +62,11 @@ expiration_monitoring:
       # Allow overriding the default labels - must *update* the existing defaults (optional)
       prometheus_labels:
         environment: dev # Cannot add a key that doesn't already exist in the global configuration
+      # Only monitor secrets that explicitly opt-in via custom metadata.
+      # In this example, only secrets with `custom_metadata.monitor == "true"` will be included in the monitoring.
+      monitor_flag:
+        field: monitor
+        truthly_value: "true"
       secrets:
       - mount_point: secrets
         secret_path: expiration_secrets

--- a/vault_monitor/expiration_monitor/README.md
+++ b/vault_monitor/expiration_monitor/README.md
@@ -95,9 +95,10 @@ A service in this context is merely a logical grouping, and beyond the fact a `s
 Each service can contain the following:
 
 * `name` - the name of the service, this will be included as a label on the associated metrics
-* `prometheus_labels` (optional) - this key allows over ridding the "global" Prometheus labels. It cannot, however, add a new key.
+* `prometheus_labels` (optional) - this key allows overriding the "global" Prometheus labels. It cannot, however, add a new key.
 * `secrets` - this key maps to a list of secrets, see below for details for secret configuration
 * `metadata_fieldnames` (optional) - allows you to override the default/"global" values for the custom metadata fieldnames
+* `monitor_flag` (optional) - allows enabling monitoring **only** for secrets that explicitly have a certain metadata key set to a defined value
 
 #### Secret Configuration
 
@@ -110,3 +111,8 @@ Each service can contain the following:
 * `mount_point` - auth engine mount point
 * `entity_id` - the entity id to monitor
 * `entity_name` - a human readable name for the entity. This does not have to match the name used in Vault, as it is not used to look up the entity.
+
+#### Monitor flag Configuration
+
+* `field` - The name of the metadata key to check in `custom_metadata`. Monitoring will only be enabled for secrets where this key is present and matches the expected value.
+* `truthy_value` - The string value that the `field` must match to activate monitoring for a given secret. If the value differs or the key is absent, the secret is skipped.

--- a/vault_monitor/expiration_monitor/create_monitors.py
+++ b/vault_monitor/expiration_monitor/create_monitors.py
@@ -28,6 +28,7 @@ def create_monitors(config: Dict, vault_client: hvac_client) -> Sequence[Expirat
         # Use deepcopy since dicts are handled by ref and tend to get overwritten otherwise
         service_prometheus_labels = deepcopy(default_prometheus_labels)
         service_prometheus_labels.update(service_config.get("prometheus_labels", {}))
+        monitor_flag = service_config.get("monitor_flag", None)
         if not check_prometheus_labels(prometheus_label_keys, service_prometheus_labels):
             raise ValueError(f"expiration_monitoring {service_config['name']} configures prometheus_labels with a key(s) which is not in the globally configured prometheus labels!")
         for secret in service_config.get("secrets", []):
@@ -49,6 +50,7 @@ def create_monitors(config: Dict, vault_client: hvac_client) -> Sequence[Expirat
                     service_config["name"],
                     service_prometheus_labels,
                     service_config.get("metadata_fieldnames", default_metadata_fieldnames),
+                    monitor_flag,
                 )
                 expiration_monitors.append(secret_monitor)
 
@@ -141,6 +143,17 @@ def get_configuration_schema() -> Dict:
                                 "dependencies": "^expiration_monitoring.prometheus_labels",
                                 "keysrules": {"type": "string", "forbidden": ["secret_path", "mount_point", "service"]},
                                 "meta": {"description": "Labels to set in the Prometheus metrics. All of the keys must already exist in the global prometheus_labels."},
+                            },
+                            "monitor_flag": {
+                                "type": "dict",
+                                "nullable": True,
+                                "schema": {
+                                    "field": {"type": "string"},
+                                    "truthy_value": {"type": "string"},
+                                },
+                                "meta": {
+                                    "description": "If set, only secrets with this custom_metadata key and matching value will be monitored."
+                                },
                             },
                             "secrets": {
                                 "type": "list",

--- a/vault_monitor/expiration_monitor/expiration_monitor.py
+++ b/vault_monitor/expiration_monitor/expiration_monitor.py
@@ -69,8 +69,8 @@ class ExpirationMonitor(ABC):
         """
         Update the current value for the metrics.
         """
-
         expiration_info = self.get_expiration_info()
-
+        if expiration_info is None:
+            return
         self.secret_last_renewal_timestamp_gauge.labels(**self.prometheus_labels).set(expiration_info.get_last_renewal_timestamp())
         self.secret_expiration_timestamp_gauge.labels(**self.prometheus_labels).set(expiration_info.get_expiration_timestamp())

--- a/vault_monitor/expiration_monitor/secret_expiration_monitor.py
+++ b/vault_monitor/expiration_monitor/secret_expiration_monitor.py
@@ -3,11 +3,15 @@ Class for monitoring secret (KV2) expiration information in HashiCorp Vault.
 """
 
 import requests
+import logging
+
+from typing import Optional
 
 from vault_monitor.expiration_monitor.expiration_monitor import ExpirationMonitor
 from vault_monitor.expiration_monitor.vault_time import ExpirationMetadata
 
 TIMEOUT = 60
+LOGGER = logging.getLogger(__name__)
 
 
 class SecretExpirationMonitor(ExpirationMonitor):
@@ -20,15 +24,54 @@ class SecretExpirationMonitor(ExpirationMonitor):
     expiration_gauge_name = "vault_secret_expiration_timestamp"
     expiration_gauge_description = "Timestamp for when a secret should expire."
 
-    def get_expiration_info(self) -> ExpirationMetadata:
-        """
-        Returns a URL for the secret being monitored
-        """
+    def __init__(
+        self,
+        mount_point,
+        monitored_path,
+        vault_client,
+        service_name,
+        prometheus_labels,
+        metadata_fieldnames,
+        monitor_flag=None,
+    ):
+        super().__init__(
+            mount_point,
+            monitored_path,
+            vault_client,
+            service_name,
+            prometheus_labels,
+            metadata_fieldnames,
+        )
+        self.monitor_flag = monitor_flag
+
+    def get_expiration_info(self) -> Optional[ExpirationMetadata]:
         response = requests.get(
             f"{self.vault_client.url}/v1/{self.mount_point}/metadata/{self.monitored_path}",
-            headers={"X-Vault-Namespace": self.vault_client.adapter.namespace, "X-Vault-Token": self.vault_client.token},
+            headers={
+                "X-Vault-Namespace": self.vault_client.adapter.namespace,
+                "X-Vault-Token": self.vault_client.token,
+            },
             timeout=TIMEOUT,
         )
         response.raise_for_status()
 
-        return ExpirationMetadata.from_metadata(response.json()["data"]["custom_metadata"], self.last_renewed_timestamp_fieldname, self.expiration_timestamp_fieldname)
+        data = response.json().get("data", {})
+        metadata = data.get("custom_metadata") or {}
+
+        if self.monitor_flag:
+            field = self.monitor_flag.get("field", "monitor")
+            truthy = self.monitor_flag.get("truthy_value", "true")
+            if metadata.get(field) != truthy:
+                LOGGER.info(
+                    "Secret '%s' skipped (monitor_flag '%s' != '%s')",
+                    self.monitored_path,
+                    field,
+                    truthy,
+                )
+                return None
+
+        return ExpirationMetadata.from_metadata(
+            metadata,
+            self.last_renewed_timestamp_fieldname,
+            self.expiration_timestamp_fieldname,
+        )


### PR DESCRIPTION
# Pull Request

This change adds support for a `monitor_flag` in the service configuration, allowing expiration monitoring to be enabled only for selected secrets.
The flag is checked in the secret's `custom_metadata`, and if the expected value is not set, the secret is skipped during monitoring.

Context: Deployed on AKS cluster with vault hashicorp on cluster kubernetes too

## Motivation

In our use case, not all Vault secrets should be monitored inside `secret_path`.
We needed a way to target only specific secrets without changing the overall structure or configuration too much.
This new flag allows for opt-in monitoring per secret using metadata, giving us better control.

Important: If the monitor_flag is not defined in the configuration, monitoring works exactly as before — all configured secrets are monitored.
There is no change in behavior unless the flag is explicitly used, so this is backward-compatible and introduces no regression.

### Why `monitor_flag` is implemented only in `SecretExpirationMonitor`

The `monitor_flag` logic was added specifically to the `SecretExpirationMonitor` class because the need to filter monitored secrets is currently specific to Vault KV v2 use cases.

This flag allows us to include only certain secrets in the expiration monitoring, based on a custom metadata key and value. It provides a clean way to opt-in secrets for monitoring without changing how they're stored or configured.

We chose **not to implement this in the base class (`ExpirationMonitor`)** because:

* The flag is **not relevant to other monitor types** like `EntityExpirationMonitor` at this point.
* Keeping this logic localized avoids unnecessary complexity in the shared base class.
* It keeps responsibilities clear: the base remains generic, and the flag handling is encapsulated where it actually applies.

If a similar requirement ever arises for entities or other monitored resources, the same pattern can be reused or extended easily.

## Prior to Submitting

Please confirm the following:

* [x] I agree to the [[Developer Certificate of Origin](https://developercertificate.org/)](https://developercertificate.org/)
* [x] I have read the [[Contribution Document](https://chatgpt.com/g/g-p-686b7b32038c8191a3f7a0fa47da4d1e-vault-hashicorp/c/CONTRIBUTING.md)](CONTRIBUTING.md)
* [x] I updated any user-documentation that is impacted by my change.
* [x] I tested my changes and ensured existing functionality wasn't broken.
* [ ] \[optional] I tested my changes on all the supported platforms.
* [ ] \[optional] In case of a major change, I communicated with the maintainers via an issue or email.
